### PR TITLE
docs: static gh-pages build

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy demo to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build static demo
+        run: pnpm --filter solid-theme-provider-demo run build:static
+
+      - name: Copy index.html to 404.html for SPA routing
+        run: cp demo/.output/public/index.html demo/.output/public/404.html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: demo/.output/public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,5 +1,6 @@
 dist
 .wrangler
+.nitro
 .output
 .vercel
 .netlify

--- a/demo/package.json
+++ b/demo/package.json
@@ -5,7 +5,8 @@
     "dev": "vite dev",
     "build": "vite build",
     "start": "vite start",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "build:static": "vite build --config vite.config.static.ts"
   },
   "dependencies": {
     "@solidjs/meta": "^0.29.4",

--- a/demo/src/app.tsx
+++ b/demo/src/app.tsx
@@ -10,6 +10,7 @@ export default function App() {
   return (
     <ThemeProvider>
       <Router
+        base={import.meta.env.BASE_URL}
         root={props => (
           <MetaProvider>
             <Title>solid-theme-provider demo</Title>

--- a/demo/vite.config.static.ts
+++ b/demo/vite.config.static.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "vite"
+import { nitroV2Plugin as nitro } from "@solidjs/vite-plugin-nitro-2"
+import { solidStart } from "@solidjs/start/config"
+import { resolve } from "path"
+import { fileURLToPath } from "url"
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url))
+
+export default defineConfig({
+  base: "/solid-theme-provider/",
+  plugins: [
+    solidStart({ ssr: false }),
+    nitro({
+      preset: "static",
+      prerender: {
+        routes: ["/"],
+        crawlLinks: false,
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      "solid-theme-provider": resolve(__dirname, "../src/index.tsx"),
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds and deploys the demo app as a static site to GitHub Pages on every push to `main`. The local development experience is unchanged — SSR remains enabled via the existing vite config, which is important for testing SSR safety of the library itself.

## What changed

- **New GitHub Actions workflow** — triggers on push to `main` (and supports manual dispatch). Builds the static demo, copies `index.html` to `404.html` to support SPA client-side routing on GitHub Pages, then uploads and deploys via the official GitHub Pages actions.

- **New static vite config** (`demo/vite.config.static.ts`) — a separate config used only for CI builds. It disables SSR (`ssr: false`), uses Nitro's `static` preset to prerender a root `index.html` shell, and sets the correct base path (`/solid-theme-provider/`) for GitHub Pages asset resolution. The original `vite.config.ts` is untouched.

- **`build:static` script** added to `demo/package.json` — invokes vite with the static config. All existing scripts (`dev`, `build`, `start`, `preview`) are unchanged.

- **`base` prop on `<Router>`** — passes Vite's built-in `import.meta.env.BASE_URL` to the router so client-side navigation resolves correctly under the `/solid-theme-provider/` subpath on GitHub Pages. In local dev, `BASE_URL` defaults to `/` so there is no behavioral change.

- **`.nitro` added to `demo/.gitignore`** — the static preset writes intermediate build artifacts to `.nitro/`, which should not be committed.

## Notes

- The GitHub Pages source must be set to **"GitHub Actions"** in the repo settings (Settings → Pages → Source). This is a one-time manual step.
- Direct URL navigation to any route (e.g. `/solid-theme-provider/toggle`) is handled by the `404.html` fallback, which GitHub Pages serves for unmatched paths — the SPA router then picks up the route client-side.
